### PR TITLE
sp版フッターの実装

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="footer-container" v-if="width>900">
+  <div v-if="isWideMenu" class="footer-container">
     <div class="footer-desc">
       <h3>AIESEC</h3>
       <p>AIESEC(アイセック)は、カナダのモントリオールに本部を置く海外インターンシップの運営を主幹事業とする世界最大級の学生団体です。アイセックの日本支部であるアイセック・ジャパンは1962年に創設され、現在では主に大学ごとに25の委員会が活動をしています。</p>
@@ -76,23 +76,45 @@
       </ul>
     </div>
   </div>
-  <div class="sp-footer-container" v-else>
+  <div v-else class="sp-footer-container">
     <div class="sp-footer-content">
-      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[0] }" @click="openItems(0)">
+      <button
+        type="button"
+        class="sp-footer-title"
+        :class="{ '_state-open': isOpened[0] }"
+        @click="openItems(0)"
+      >
         AIESECについて
       </button>
-      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
-        <div class="sp-footer-item" :class="{ '_state-open': isOpened[0] }" v-if="isOpened[0]">
+      <transition
+        name="sp-footer-item"
+        @before-enter="beforeEnter"
+        @enter="enter"
+        @before-leave="beforeLeave"
+        @leave="leave"
+      >
+        <div v-if="isOpened[0]" class="sp-footer-item">
           <p>AIESEC(アイセック)は、カナダのモントリオールに本部を置く海外インターンシップの運営を主幹事業とする世界最大級の学生団体です。アイセックの日本支部であるアイセック・ジャパンは1962年に創設され、現在では主に大学ごとに25の委員会が活動をしています。</p>
         </div>
       </transition>
     </div>
     <div class="sp-footer-content">
-      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[1] }" @click="openItems(1)">
+      <button
+        type="button"
+        class="sp-footer-title"
+        :class="{ '_state-open': isOpened[1] }"
+        @click="openItems(1)"
+      >
         About
       </button>
-      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
-        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[1] }" v-if="isOpened[1]">
+      <transition
+        name="sp-footer-item"
+        @before-enter="beforeEnter"
+        @enter="enter"
+        @before-leave="beforeLeave"
+        @leave="leave"
+      >
+        <ul v-if="isOpened[1]" class="sp-footer-item">
           <li>
             <a href="#">AIESECについて</a>
           </li>
@@ -115,11 +137,22 @@
       </transition>
     </div>
     <div class="sp-footer-content">
-      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[2] }" @click="openItems(2)">
+      <button
+        type="button"
+        class="sp-footer-title"
+        :class="{ '_state-open': isOpened[2] }"
+        @click="openItems(2)"
+      >
         For Students
       </button>
-      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
-        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[2] }" v-if="isOpened[2]">
+      <transition
+        name="sp-footer-item"
+        @before-enter="beforeEnter"
+        @enter="enter"
+        @before-leave="beforeLeave"
+        @leave="leave"
+      >
+        <ul v-if="isOpened[2]" class="sp-footer-item">
           <li>
             <a href="#">海外インターンシップに参加する</a>
           </li>
@@ -142,11 +175,22 @@
       </transition>
     </div>
     <div class="sp-footer-content">
-      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[3] }" @click="openItems(3)">
+      <button
+        type="button"
+        class="sp-footer-title"
+        :class="{ '_state-open': isOpened[3] }"
+        @click="openItems(3)"
+      >
         For Companies
       </button>
-      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
-        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[3] }" v-if="isOpened[3]">
+      <transition
+        name="sp-footer-item"
+        @before-enter="beforeEnter"
+        @enter="enter"
+        @before-leave="beforeLeave"
+        @leave="leave"
+      >
+        <ul v-if="isOpened[3]" class="sp-footer-item">
           <li>
             <a href="#">海外インターン生を受け入れる</a>
           </li>
@@ -160,11 +204,22 @@
       </transition>
     </div>
     <div class="sp-footer-content">
-      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[4] }" @click="openItems(4)">
+      <button
+        type="button"
+        class="sp-footer-title"
+        :class="{ '_state-open': isOpened[4] }"
+        @click="openItems(4)"
+      >
         Press & Alumni
       </button>
-      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
-        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[4] }" v-if="isOpened[4]">
+      <transition
+        name="sp-footer-item"
+        @before-enter="beforeEnter"
+        @enter="enter"
+        @before-leave="beforeLeave"
+        @leave="leave"
+      >
+        <ul v-if="isOpened[4]" class="sp-footer-item">
           <li>
             <a href="#">プレスルーム</a>
           </li>
@@ -187,22 +242,30 @@ export default {
       isOpened: [false,false,false,false,false]
     };
   },
+  computed: {
+    isWideMenu() {
+      if (this.width < 900) {
+        return false
+      }
+      return true
+    }
+  },
   methods: {
-    openItems: function(index) {
-      this.isOpened.splice(index,1,!this.isOpened[index]);
+    openItems(index) {
+      this.isOpened.splice(index,1,!this.isOpened[index])
     },
-    beforeEnter: function(el) {
-      el.style.height = '0';
+    beforeEnter(el) {
+      el.style.height = '0'
     },
-    enter: function(el) {
-      el.style.height = el.scrollHeight + 'px';
+    enter(el) {
+      el.style.height = el.scrollHeight + 'px'
     },
-    beforeLeave: function(el) {
-      el.style.height = el.scrollHeight + 'px';
+    beforeLeave(el) {
+      el.style.height = el.scrollHeight + 'px'
     },
-    leave: function(el) {
-      el.style.height = '0';
-  }
+    leave(el) {
+      el.style.height = '0'
+    }
   }
 }
 </script>
@@ -320,8 +383,5 @@ export default {
   100% {
     opacity: 0;
   }
-}
-._state-open {
-  max-height: 500px;
 }
 </style>

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="footer-container">
+  <div class="footer-container" v-if="width>900">
     <div class="footer-desc">
       <h3>AIESEC</h3>
       <p>AIESEC(アイセック)は、カナダのモントリオールに本部を置く海外インターンシップの運営を主幹事業とする世界最大級の学生団体です。アイセックの日本支部であるアイセック・ジャパンは1962年に創設され、現在では主に大学ごとに25の委員会が活動をしています。</p>
@@ -76,7 +76,114 @@
       </ul>
     </div>
   </div>
+  <div class="sp-footer-container" v-else>
+    <div class="sp-footer-content">
+      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[0] }" @click="openItems(0)">
+        AIESECについて
+      </button>
+      <div class="sp-footer-item" :class="{ '_state-open': isOpened[0] }" v-if="isOpened[0]">
+        <p>AIESEC(アイセック)は、カナダのモントリオールに本部を置く海外インターンシップの運営を主幹事業とする世界最大級の学生団体です。アイセックの日本支部であるアイセック・ジャパンは1962年に創設され、現在では主に大学ごとに25の委員会が活動をしています。</p>
+      </div>
+    </div>
+    <div class="sp-footer-content">
+      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[1] }" @click="openItems(1)">
+        About
+      </button>
+      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[1] }" v-if="isOpened[1]">
+        <li>
+          <a href="#">AIESECについて</a>
+        </li>
+        <li>
+          <a href="#">パートナーシップについて</a>
+        </li>
+        <li>
+          <a href="#">団体情報</a>
+        </li>
+        <li>
+          <a href="#">安全への取り組み</a>
+        </li>
+        <li>
+          <a href="#">個人情報の取り扱い</a>
+        </li>
+        <li>
+          <a href="#">お問い合わせ</a>
+        </li>
+      </ul>
+    </div>
+    <div class="sp-footer-content">
+      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[2] }" @click="openItems(2)">
+        For Students
+      </button>
+      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[2] }" v-if="isOpened[2]">
+        <li>
+          <a href="#">海外インターンシップに参加する</a>
+        </li>
+        <li>
+          <a href="#">海外ボランティアに参加する</a>
+        </li>
+        <li>
+          <a href="#">体験記を見る</a>
+        </li>
+        <li>
+          <a href="#">参加の流れと費用</a>
+        </li>
+        <li>
+          <a href="#">危機管理サポート</a>
+        </li>
+        <li>
+          <a href="#">話を聞いてみる</a>
+        </li>
+      </ul>
+    </div>
+    <div class="sp-footer-content">
+      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[3] }" @click="openItems(3)">
+        For Companies
+      </button>
+      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[3] }" v-if="isOpened[3]">
+        <li>
+          <a href="#">海外インターン生を受け入れる</a>
+        </li>
+        <li>
+          <a href="#">受け入れ事例を見る</a>
+        </li>
+        <li>
+          <a href="#">受け入れの流れと費用</a>
+        </li>
+      </ul>
+    </div>
+    <div class="sp-footer-content">
+      <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[4] }" @click="openItems(4)">
+        Press & Alumni
+      </button>
+      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[4] }" v-if="isOpened[4]">
+        <li>
+          <a href="#">プレスルーム</a>
+        </li>
+        <li>
+          <a href="#">アルムナイの方</a>
+        </li>
+      </ul>
+    </div>
+  </div>
 </template>
+
+<script>
+export default {
+  props: [
+    "width"
+  ],
+  data() {
+    return {
+      isOpened: [false,false,false,false,false]
+    };
+  },
+  methods: {
+    openItems: function(index) {
+      this.isOpened.splice(index,1,!this.isOpened[index]);
+    },
+  }
+}
+</script>
 
 <style scoped lang="scss">
 .footer-container {
@@ -114,6 +221,38 @@
   max-width: 220px;
   li {
     list-style-type: none;
+  }
+}
+.sp-footer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: $light-gray;
+}
+.sp-footer-content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+}
+.sp-footer-title {
+  width: 100%;
+  font-size: 16px;
+  color: $blue;
+  letter-spacing: 2px;
+  padding: 20px;
+}
+.sp-footer-item {
+  color: $dark-gray;
+  width: 80%;
+  letter-spacing: 2px;
+  line-height: 24px;
+  a {
+    color: $dark-gray;
+    text-decoration: none;
+    display: block;
+    margin: 10px auto;
   }
 }
 </style>

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -81,88 +81,98 @@
       <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[0] }" @click="openItems(0)">
         AIESECについて
       </button>
-      <div class="sp-footer-item" :class="{ '_state-open': isOpened[0] }" v-if="isOpened[0]">
-        <p>AIESEC(アイセック)は、カナダのモントリオールに本部を置く海外インターンシップの運営を主幹事業とする世界最大級の学生団体です。アイセックの日本支部であるアイセック・ジャパンは1962年に創設され、現在では主に大学ごとに25の委員会が活動をしています。</p>
-      </div>
+      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
+        <div class="sp-footer-item" :class="{ '_state-open': isOpened[0] }" v-if="isOpened[0]">
+          <p>AIESEC(アイセック)は、カナダのモントリオールに本部を置く海外インターンシップの運営を主幹事業とする世界最大級の学生団体です。アイセックの日本支部であるアイセック・ジャパンは1962年に創設され、現在では主に大学ごとに25の委員会が活動をしています。</p>
+        </div>
+      </transition>
     </div>
     <div class="sp-footer-content">
       <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[1] }" @click="openItems(1)">
         About
       </button>
-      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[1] }" v-if="isOpened[1]">
-        <li>
-          <a href="#">AIESECについて</a>
-        </li>
-        <li>
-          <a href="#">パートナーシップについて</a>
-        </li>
-        <li>
-          <a href="#">団体情報</a>
-        </li>
-        <li>
-          <a href="#">安全への取り組み</a>
-        </li>
-        <li>
-          <a href="#">個人情報の取り扱い</a>
-        </li>
-        <li>
-          <a href="#">お問い合わせ</a>
-        </li>
-      </ul>
+      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
+        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[1] }" v-if="isOpened[1]">
+          <li>
+            <a href="#">AIESECについて</a>
+          </li>
+          <li>
+            <a href="#">パートナーシップについて</a>
+          </li>
+          <li>
+            <a href="#">団体情報</a>
+          </li>
+          <li>
+            <a href="#">安全への取り組み</a>
+          </li>
+          <li>
+            <a href="#">個人情報の取り扱い</a>
+          </li>
+          <li>
+            <a href="#">お問い合わせ</a>
+          </li>
+        </ul>
+      </transition>
     </div>
     <div class="sp-footer-content">
       <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[2] }" @click="openItems(2)">
         For Students
       </button>
-      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[2] }" v-if="isOpened[2]">
-        <li>
-          <a href="#">海外インターンシップに参加する</a>
-        </li>
-        <li>
-          <a href="#">海外ボランティアに参加する</a>
-        </li>
-        <li>
-          <a href="#">体験記を見る</a>
-        </li>
-        <li>
-          <a href="#">参加の流れと費用</a>
-        </li>
-        <li>
-          <a href="#">危機管理サポート</a>
-        </li>
-        <li>
-          <a href="#">話を聞いてみる</a>
-        </li>
-      </ul>
+      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
+        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[2] }" v-if="isOpened[2]">
+          <li>
+            <a href="#">海外インターンシップに参加する</a>
+          </li>
+          <li>
+            <a href="#">海外ボランティアに参加する</a>
+          </li>
+          <li>
+            <a href="#">体験記を見る</a>
+          </li>
+          <li>
+            <a href="#">参加の流れと費用</a>
+          </li>
+          <li>
+            <a href="#">危機管理サポート</a>
+          </li>
+          <li>
+            <a href="#">話を聞いてみる</a>
+          </li>
+        </ul>
+      </transition>
     </div>
     <div class="sp-footer-content">
       <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[3] }" @click="openItems(3)">
         For Companies
       </button>
-      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[3] }" v-if="isOpened[3]">
-        <li>
-          <a href="#">海外インターン生を受け入れる</a>
-        </li>
-        <li>
-          <a href="#">受け入れ事例を見る</a>
-        </li>
-        <li>
-          <a href="#">受け入れの流れと費用</a>
-        </li>
-      </ul>
+      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
+        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[3] }" v-if="isOpened[3]">
+          <li>
+            <a href="#">海外インターン生を受け入れる</a>
+          </li>
+          <li>
+            <a href="#">受け入れ事例を見る</a>
+          </li>
+          <li>
+            <a href="#">受け入れの流れと費用</a>
+          </li>
+        </ul>
+      </transition>
     </div>
     <div class="sp-footer-content">
       <button type="button" class="sp-footer-title" :class="{ '_state-open': isOpened[4] }" @click="openItems(4)">
         Press & Alumni
       </button>
-      <ul class="sp-footer-item" :class="{ '_state-open': isOpened[4] }" v-if="isOpened[4]">
-        <li>
-          <a href="#">プレスルーム</a>
-        </li>
-        <li>
-          <a href="#">アルムナイの方</a>
-        </li>
-      </ul>
+      <transition name="sp-footer-item" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
+        <ul class="sp-footer-item" :class="{ '_state-open': isOpened[4] }" v-if="isOpened[4]">
+          <li>
+            <a href="#">プレスルーム</a>
+          </li>
+          <li>
+            <a href="#">アルムナイの方</a>
+          </li>
+        </ul>
+      </transition>
     </div>
   </div>
 </template>
@@ -181,6 +191,18 @@ export default {
     openItems: function(index) {
       this.isOpened.splice(index,1,!this.isOpened[index]);
     },
+    beforeEnter: function(el) {
+      el.style.height = '0';
+    },
+    enter: function(el) {
+      el.style.height = el.scrollHeight + 'px';
+    },
+    beforeLeave: function(el) {
+      el.style.height = el.scrollHeight + 'px';
+    },
+    leave: function(el) {
+      el.style.height = '0';
+  }
   }
 }
 </script>
@@ -239,20 +261,67 @@ export default {
 .sp-footer-title {
   width: 100%;
   font-size: 16px;
+  line-height: 16px;
   color: $blue;
   letter-spacing: 2px;
   padding: 20px;
+}
+.sp-footer-title::after {
+  content: "+";
+  font-size: 24px;
+  float: right;
+  -moz-transition: -moz-transform 0.3s ease-in-out;
+  -o-transition: -o-transform 0.3s ease-in-out;
+  -webkit-transition: -webkit-transform 0.3s ease-in-out;
+  transition: transform 0.3s ease-in-out;
+}
+._state-open::after {
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  transform: rotate(45deg);
 }
 .sp-footer-item {
   color: $dark-gray;
   width: 80%;
   letter-spacing: 2px;
   line-height: 24px;
+  font-size: 12px;
+  overflow: hidden;
+  transition: height 0.4s ease-in-out;
   a {
     color: $dark-gray;
     text-decoration: none;
     display: block;
     margin: 10px auto;
   }
+  &-enter-active{
+    animation-duration: 1s;
+    animation-fill-mode: both;
+    animation-name: sp-footer-item--anime__opend;
+  }
+  &-leave-active{
+    animation-duration: 1s;
+    animation-fill-mode: both;
+    animation-name: sp-footer-item--anime__closed;
+  }
+}
+@keyframes sp-footer-item--anime__opend {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+   }
+}
+@keyframes sp-footer-item--anime__closed {
+  0% {
+   opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+._state-open {
+  max-height: 500px;
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,7 @@
   <div>
     <Header/>
     <nuxt/>
-    <Footer/>
+    <Footer :width="width" />
   </div>
 </template>
 
@@ -13,6 +13,27 @@ export default {
   components: {
     Header,
     Footer
+  },
+  data () {
+    return {
+      width: 0
+    }
+  },
+  created () {
+    if (process.client) {
+      window.addEventListener('resize', this.handleResize)
+      this.handleResize()
+    }
+  },
+  destroyed () {
+    if (process.client) {
+      window.removeEventListener('resize', this.handleResize)
+    }
+  },
+  methods: {
+    handleResize () {
+      this.width = window.innerWidth
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->
#### #55 #80  SP版フッターの追加

## 概要
<!-- 目的 -->
画面幅が狭い時にSP版フッターへ切り替えたい

## 変更内容
<!-- 実装の内容, スクショなど -->
- default.vueで画面幅取得、Footer.vueへpropsで渡す
- Footer.vueにSP版を追加、画面幅900px以下の時にSP版へ表示切り替え
<img width="354" alt="スクリーンショット 2020-09-20 12 30 21" src="https://user-images.githubusercontent.com/55129947/93693726-8b30d980-fb3e-11ea-9c33-cf696c1fbf20.png">


## レビューポイント
<!-- レビューで見てほしいところ -->
アドバイスほしい点
- アコーディオン型にしてみました、他良さそうなデザインあれば。
- 切替を(PCフッターが崩れる)900pxにしたため、幅広な段階からsp版に変わる点


