### PR TITLE
spヘッダーの追加

### DIFF
--- a/components/base/Header.vue
+++ b/components/base/Header.vue
@@ -2,14 +2,25 @@
   <header class="header-container">
     <nav>
       <ul>
-        <li>
+        <li class="pc-header-item">
           <a href="/outgoing">海外インターンシップに参加する</a>
         </li>
-        <li>
+        <li class="pc-header-item">
           <a href="/incoming">海外インターン生を受け入れる</a>
         </li>
-        <li>
+        <li class="pc-header-item">
           <a href="/about">About Us</a>
+        </li>
+      </ul>
+      <ul class="sp-header">
+        <li class="sp-header-item">
+          <a href="/outgoing">Outgoing</a>
+        </li>
+        <li class="sp-header-item">
+          <a href="/incoming">Incoming</a>
+        </li>
+        <li class="sp-header-item">
+          <a href="/about">About</a>
         </li>
       </ul>
     </nav>
@@ -34,7 +45,7 @@
     display: flex;
     justify-content: flex-end;
   }
-  li {
+  .pc-header-item {
     margin-left: 90px;
     list-style-type: none;
   }
@@ -47,6 +58,18 @@
   }
   a:hover {
     opacity: 0.7;
+  }
+}
+.sp-header-item {
+  display: none;
+}
+@media only screen and (max-width : 980px) {
+  .pc-header-item {
+    display: none;
+  }
+  .sp-header-item {
+    display: block;
+    margin-left: 50px;
   }
 }
 </style>


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->
#61 画面幅によるヘッダー切り替え

## 概要
<!-- 目的 -->
SP版ヘッダー（仮）を作る

## 変更内容
<!-- 実装の内容, スクショなど -->
<img width="326" alt="スクリーンショット 2020-09-28 10 49 25" src="https://user-images.githubusercontent.com/55129947/94382680-9f955780-0178-11eb-8212-e6238698d269.png">


## レビューポイント
<!-- レビューで見てほしいところ -->
- 画面幅980pxで切り替わるか
- 切り替え付近でのSPヘッダーの余白が（画面幅に対して）狭く感じるのが少し気になっています

