### PR TITLE
headerに被ってくる要素があるので修正

### DIFF
--- a/assets/scss/_variable.scss
+++ b/assets/scss/_variable.scss
@@ -16,3 +16,7 @@ $white: white;
 $lato: "Lato";
 $yu-gothic: "Yu Gothic Medium",YuGothic,"Yu Gothic";
 $fonts: $lato,$yu-gothic,sans-serif;
+
+// z-index
+$headerIndex : 9999;
+

--- a/components/base/Header.vue
+++ b/components/base/Header.vue
@@ -29,6 +29,7 @@
 
 <style scoped lang="scss">
 .header-container {
+  z-index: $headerIndex;
   position: fixed;
   top: 0;
   right: 0;
@@ -38,7 +39,7 @@
   height: 80px;
   line-height: 80px;
   padding: 0px 5%;
-  border-bottom-style: solid; 
+  border-bottom-style: solid;
   border-bottom-width: 0.5px;
   border-bottom-color: $gray;
   ul {


### PR DESCRIPTION
## Issue
ないです。

## 概要

一部headerより上に重なってしまう要素があるので、z-indexの管理を追加しました。

![スクリーンショット 2021-05-02 13 17 13](https://user-images.githubusercontent.com/24384795/116801874-cf5e7080-ab48-11eb-9eb8-07608df964de.png)

## 変更内容
<!-- 実装の内容, スクショなど -->

## レビューポイント
- z-indexの管理方法
- 命名規則


