### PR TITLE
headerにオンラインイベントを追加.ついでにホバー時の表示も追加

### DIFF
--- a/components/base/Header.vue
+++ b/components/base/Header.vue
@@ -4,17 +4,19 @@
       <ul>
         <li class="pc-header-item" v-on:mouseleave="mouseLeaveAction" v-on:mouseover="mouseOverAction">
           <a href="">海外インターンシップについて</a>
-          <ul v-show="isShowNestedItems" class="pc-header-nested">
-            <li class="pc-header-nested-item">
-              <a href="/outgoing">海外インターンシップに参加する</a>
-            </li>
-            <li class="pc-header-nested-item">
-              <a href="/incoming">海外インターン生を受け入れる</a>
-            </li>
-            <li class="pc-header-nested-item">
-              <a href="">安全への取り組み</a>
-            </li>
-          </ul>
+          <div v-show="isShowNestedItems" class="pc-header-nested">
+            <ul class="pc-header-nested-list">
+              <li class="pc-header-nested-item">
+                <a href="/outgoing">海外インターンシップに参加する</a>
+              </li>
+              <li class="pc-header-nested-item">
+                <a href="/incoming">海外インターン生を受け入れる</a>
+              </li>
+              <li class="pc-header-nested-item">
+                <a href="">安全への取り組み</a>
+              </li>
+            </ul>
+          </div>
         </li>
         <li class="pc-header-item">
           <a href="">オンラインイベントについて</a>
@@ -86,9 +88,13 @@ export default {
 
     &-nested {
       position: absolute;
-      top: 85px;
-      flex-flow: column;
-      border-left: $gray solid 1px;
+      top: 80px;
+
+      &-list {
+        margin-top: 5px;
+        flex-flow: column;
+        border-left: $gray solid 1px;
+      }
 
       &-item {
         margin-left: 10px;

--- a/components/base/Header.vue
+++ b/components/base/Header.vue
@@ -2,9 +2,9 @@
   <header class="header-container">
     <nav>
       <ul>
-        <li class="pc-header-item" v-on:mouseover="mouseOverAction" v-on:mouseleave="mouseLeaveAction">
+        <li class="pc-header-item" v-on:mouseleave="mouseLeaveAction" v-on:mouseover="mouseOverAction">
           <a href="">海外インターンシップについて</a>
-          <ul class="pc-header-nested" v-show="isShowNestedItems">
+          <ul v-show="isShowNestedItems" class="pc-header-nested">
             <li class="pc-header-nested-item">
               <a href="/outgoing">海外インターンシップに参加する</a>
             </li>
@@ -38,7 +38,26 @@
   </header>
 </template>
 
-<style scoped lang="scss">
+<script>
+export default {
+  data() {
+    return {
+      isShowNestedItems: false
+    }
+  },
+  methods: {
+    mouseOverAction() {
+      this.isShowNestedItems = true
+    },
+    mouseLeaveAction() {
+      this.isShowNestedItems = false
+    }
+  }
+}
+
+</script>
+
+<style lang="scss" scoped>
 
 .header-container {
   position: fixed;
@@ -53,20 +72,24 @@
   border-bottom-style: solid;
   border-bottom-width: 0.5px;
   border-bottom-color: $gray;
+
   ul {
     display: flex;
     justify-content: flex-end;
   }
-  .pc-header{
+
+  .pc-header {
     &-item {
       margin-left: 90px;
       list-style-type: none;
     }
-    &-nested{
+
+    &-nested {
       position: absolute;
-      top:85px;
+      top: 85px;
       flex-flow: column;
       border-left: $gray solid 1px;
+
       &-item {
         margin-left: 10px;
         list-style-type: none;
@@ -83,6 +106,7 @@
     font-size: 16px;
     letter-spacing: 2px;
   }
+
   a:hover {
     opacity: 0.7;
   }
@@ -92,7 +116,7 @@
   display: none;
 }
 
-@media only screen and (max-width : 980px) {
+@media only screen and (max-width: 980px) {
   .pc-header-item {
     display: none;
   }
@@ -103,21 +127,3 @@
 }
 </style>
 
-<script>
-export default {
-  data() {
-    return {
-      isShowNestedItems: false
-    }
-  },
-  methods: {
-    mouseOverAction(){
-      this.isShowNestedItems = true
-    },
-    mouseLeaveAction(){
-      this.isShowNestedItems = false
-    }
-  }
-}
-
-</script>

--- a/components/base/Header.vue
+++ b/components/base/Header.vue
@@ -113,13 +113,9 @@ export default {
   methods: {
     mouseOverAction(){
       this.isShowNestedItems = true
-      console.log('hover')
-      console.log(this.isShowNestedItems)
     },
     mouseLeaveAction(){
       this.isShowNestedItems = false
-      console.log('leave')
-      console.log(this.isShowNestedItems)
     }
   }
 }

--- a/components/base/Header.vue
+++ b/components/base/Header.vue
@@ -2,11 +2,22 @@
   <header class="header-container">
     <nav>
       <ul>
-        <li class="pc-header-item">
-          <a href="/outgoing">海外インターンシップに参加する</a>
+        <li class="pc-header-item" v-on:mouseover="mouseOverAction" v-on:mouseleave="mouseLeaveAction">
+          <a href="">海外インターンシップについて</a>
+          <ul class="pc-header-nested" v-show="isShowNestedItems">
+            <li class="pc-header-nested-item">
+              <a href="/outgoing">海外インターンシップに参加する</a>
+            </li>
+            <li class="pc-header-nested-item">
+              <a href="/incoming">海外インターン生を受け入れる</a>
+            </li>
+            <li class="pc-header-nested-item">
+              <a href="">安全への取り組み</a>
+            </li>
+          </ul>
         </li>
         <li class="pc-header-item">
-          <a href="/incoming">海外インターン生を受け入れる</a>
+          <a href="">オンラインイベントについて</a>
         </li>
         <li class="pc-header-item">
           <a href="/about">About Us</a>
@@ -28,6 +39,7 @@
 </template>
 
 <style scoped lang="scss">
+
 .header-container {
   position: fixed;
   top: 0;
@@ -38,17 +50,32 @@
   height: 80px;
   line-height: 80px;
   padding: 0px 5%;
-  border-bottom-style: solid; 
+  border-bottom-style: solid;
   border-bottom-width: 0.5px;
   border-bottom-color: $gray;
   ul {
     display: flex;
     justify-content: flex-end;
   }
-  .pc-header-item {
-    margin-left: 90px;
-    list-style-type: none;
+  .pc-header{
+    &-item {
+      margin-left: 90px;
+      list-style-type: none;
+    }
+    &-nested{
+      position: absolute;
+      top:85px;
+      flex-flow: column;
+      border-left: $gray solid 1px;
+      &-item {
+        margin-left: 10px;
+        list-style-type: none;
+        line-height: 30px;
+      }
+    }
   }
+
+
   a {
     color: $gray;
     font-weight: bold;
@@ -60,9 +87,11 @@
     opacity: 0.7;
   }
 }
+
 .sp-header-item {
   display: none;
 }
+
 @media only screen and (max-width : 980px) {
   .pc-header-item {
     display: none;
@@ -73,3 +102,26 @@
   }
 }
 </style>
+
+<script>
+export default {
+  data() {
+    return {
+      isShowNestedItems: false
+    }
+  },
+  methods: {
+    mouseOverAction(){
+      this.isShowNestedItems = true
+      console.log('hover')
+      console.log(this.isShowNestedItems)
+    },
+    mouseLeaveAction(){
+      this.isShowNestedItems = false
+      console.log('leave')
+      console.log(this.isShowNestedItems)
+    }
+  }
+}
+
+</script>


### PR DESCRIPTION
## Issue
なし

## 概要
headerの項目が一部古いので最新のものに更新します


![スクリーンショット 2021-05-02 13 27 48](https://user-images.githubusercontent.com/24384795/116802451-d2a82b00-ab4d-11eb-930c-dd2996a93ca9.png)
![スクリーンショット 2021-05-02 13 27 54](https://user-images.githubusercontent.com/24384795/116802453-d3d95800-ab4d-11eb-9df3-3c2cdd985228.png)


## 変更内容

- オンラインイベントについてを追加
- 海外インターンシップについてをまとめる
- mouse over時のメニューを追加

![スクリーンショット 2021-05-02 14 39 54](https://user-images.githubusercontent.com/24384795/116803664-b6f45300-ab54-11eb-857e-841f4e48ae71.png)


## レビューポイント

- スマホ対応は一旦後回しにします
- 背景色と同化してめちゃめちゃみにくいのは後でデザイン調整
- スクロール位置によって文字色、ボーダーが消えるやつはTOPができてから

