### PR TITLE
height の修正

### DIFF
--- a/components/incoming/CorporationMerit.vue
+++ b/components/incoming/CorporationMerit.vue
@@ -32,6 +32,7 @@
 
 .corporation-merit {
   width: 100%;
+  height: 80vh;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Issue
#191 

## 概要
#210 ですでに大方の修正は終わってました（背景画像の差し替えなど）
高さだけ上方向にズレてたので修正してます

また、見出しが必要か？という点に関しては今回はいらないと思います
このセクションのコンテンツ量が多くない状態で見出しをつけると冗長になるし、h3の要素が3つすでにあるので見出しの役割は果たせているからです

## 変更内容
![image](https://user-images.githubusercontent.com/34568694/122933580-bbe1c000-d3a9-11eb-95d7-4317ce5e5f9f.png)


