### PR TITLE
[BUG]安全への取り組みの画面幅によってはヘッダーと被る

### DIFF
--- a/components/safety/Top.vue
+++ b/components/safety/Top.vue
@@ -27,7 +27,8 @@
     background-size: cover;
 
     @include sp {
-      height: 100vh;
+      min-height: min-content;
+      height: 50rem;
     }
   }
 


### PR DESCRIPTION
画面サイズに応じて無駄なく高さ調整されるようにしようとしたらミスった。