### PR TITLE
Update Top.vue

### DIFF
--- a/components/global-youth-dialogue/Top.vue
+++ b/components/global-youth-dialogue/Top.vue
@@ -83,7 +83,7 @@
     text-align: center;
     margin: 1rem auto;
     font-size: 1rem;
-    line-height: 2;
+    line-height: 1.5;
     color: white;
     letter-spacing: 0.1rem;
 


### PR DESCRIPTION
トップページの訴求部分の行間を縮めました
確認お願いします！！

## Issue
<!-- Issue番号 -->

## 概要
トップページのテキストの行間を 2 から 1.5 に修正しました！

## 変更内容
https://docs.google.com/spreadsheets/d/1U8fc6YwXsi3M3Js1fsD_RE9H3YINLUGIm9IoGFeymb4/edit#gid=42113201
これに則って文言を追加した所、背景画像からテキストがはみ出してしまったため、行間を修正した

## レビューポイント
テキストが背景画像上に収まっているか確認お願いします！！


