### PR TITLE
LP サイトへのグーグルアナリティクス適用

### DIFF
--- a/static/lp/recruit2022/index.html
+++ b/static/lp/recruit2022/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-222793123-2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-222793123-2');
+  </script>
+
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
グーグルアナリティクスのトラッキングコードを〈head〉タグの直後に挿入しました。

## Issue

## 概要
global youth dialogue / 採用ランディングページへの流入を測定する旨の要望があり、
トラッキングコードをグーグルアナリティクスの[紹介サイト](https://web-kanji.com/posts/google-analytics-setting)に記載の手順で挿入しました。
試験的に導入して経過観察したいと思います。

## 変更内容
〈head〉タグの直後にトラッキングコードを挿入した。

## レビューポイント
インデント等のミスがないか


