### PR TITLE
google tag manager 適用コードの設置

### DIFF
--- a/static/lp/recruit2022/index.html
+++ b/static/lp/recruit2022/index.html
@@ -9,7 +9,17 @@
     gtag('js', new Date());
     gtag('config', 'UA-222793123-2');
   </script>
-
+  
+  <!-- Google Tag Manager -->
+  <script>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+     })(window,document,'script','dataLayer','GTM-TMPGR44');
+  </script>
+  <!-- End Google Tag Manager -->
+  
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -46,6 +56,15 @@
   <link rel="stylesheet" href="./assets/css/style.css">
 </head>
 <body>
+  
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TMPGR44"
+     height="0" width="0" style="display:none;visibility:hidden">
+    </iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  
   <header class="l-header js-header">
     <div class="l-header__inner">
       <a href="./" id="js-header__logo" class="p-header__logo">AIESEC</a>


### PR DESCRIPTION
新歓LPのクリックを計測する為に、グーグルタグマネージャーを設置する。
head タグ内に1つ、body タグ開始直後に1つ、適用コードを追記した。
develop に適用したものを master にマージする

## Issue
<!-- Issue番号 -->

## 概要
新歓LP内のクリックイベントを計測するため

## 変更内容
head タグ内に1つ、body タグ開始直後に1つ、適用コードを追記した。
（develop と同様）

## レビューポイント
意図せぬ改行、空白、誤字の有無  
コードが適切に改行されて読みやすいかどうか


