### PR TITLE
branchの名前が間違っていた場合に気がつける様にactionを追加

### DIFF
--- a/.github/workflows/branchNameChacker.yaml
+++ b/.github/workflows/branchNameChacker.yaml
@@ -1,0 +1,38 @@
+## github flowに載らない運用をしていた場合に気がつける様にactionを作りました。
+## master以外はそんなに厳密出なくても何とかなります。
+name: "Branch Name checker"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  branchNameCheckJob:
+    name: branch name cheker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch names
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+      - name: Current branch name
+        run: |
+          echo " ${{ steps.branch-name.outputs.current_branch }}"
+      - name: chack branch name to master
+        if: StartsWith(steps.branch-name.outputs.current_branch , 'hotfix') || startsWith(steps.branch-name.outputs.current_branch, 'release')
+        id: name_check
+        run: |
+          echo "Running on branch: ${{ steps.branch-name.outputs.current_branch }}"
+          echo "this branch name is collect."
+      - name: Error message
+        if: steps.name_check.conclusion == 'skipped'
+        run: |
+          echo "this branch ${{ steps.branch-name.outputs.current_branch }} is not valid"
+          echo "please rename branch. release/** or hotfix/**"
+          echo "今のブランチはリリーすフローに合っていない可能性があります"
+          exit 1

--- a/.github/workflows/branchNameChacker.yaml
+++ b/.github/workflows/branchNameChacker.yaml
@@ -3,10 +3,6 @@
 name: "Branch Name checker"
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - master
   pull_request:
     branches:
       - main


### PR DESCRIPTION

## 概要
masterへの適応は慎重に行なってもらいたいので、運用を間違えていた際に気がつける様にactionを追加しました。

masterへのPR作成時に動きます。
ブランチ名が`release/** ` or `hotfix/**`　になっていないと失敗します。
この運用はgithub flowに従うものです。

もしこのCIが落ちた場合は、リリースフローを見直してみてください。

## レビューポイント
理解しなくても大丈夫です。
このworkflowの目的が分かればapproveしてください。


