### PR TITLE
Google Tag Manager の設置に関して、release ブランチを切る

### DIFF
--- a/static/lp/recruit2022/index.html
+++ b/static/lp/recruit2022/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-222793123-2"></script>
   <script>


### PR DESCRIPTION
Google Tag Manager の設置に関して、release ブランチを切る。

## Issue
<!-- Issue番号 -->

## 概要
LP 内のクリック計測の為

## 変更内容
head タグ、及び body タグの直後に、 google tag manager 適用コードが設置されている。

## レビューポイント
release ブランチとして適切か


