### PR TITLE
安全管理委員会開催報告の更新

### DIFF
--- a/components/safety/Committee.vue
+++ b/components/safety/Committee.vue
@@ -43,6 +43,16 @@ export default {
       openLogs: false,
       committeeLogs: [
         {
+          title: '令和四年度第一回安全管理委員会開催報告',
+          describe: '令和4年5月24・25日に安全管理委員会を開催いたしました。',
+          link: 'https://drive.google.com/file/d/1jgH8BEp3w8BHuTE-0SHWLj2Wwyal6zQP/view?usp=sharing'
+        },
+        {
+          title: '令和三年度第二回安全管理委員会開催報告',
+          describe: '令和3年11月16日に安全管理委員会を開催いたしました。',
+          link: 'https://drive.google.com/file/d/1zmp8_otRYU9Bg689wE6cNfDh8_-CKrLU/view?usp=sharing'
+        },
+        {
           title: '令和三年度第一回安全管理委員会開催報告',
           describe: '令和3年5月27日に安全管理委員会を開催いたしました。',
           link: 'https://drive.google.com/file/d/1nIld1vzD8zBt7olnIC8-D7Lcl8AO0G1i/view?usp=sharing'


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->

## 概要
「安全への取り組み」ページに所在の、
令和三年度第二回及び、令和四年度第一回安全管理委員会開催報告を更新
編集ファイル / Commitee.vue 

## 変更内容
Commitee.vue の data 内のリスト commiteeLogs の先頭に、title / describe / link をそれぞれ増分だけ追加。
開催報告用 PDF は、MC ドライブ > AJ HP > 安全への取り組み > 開催報告 に所在。

## レビューポイント
プレビューにおいて、正常に表示されているか、誤字脱字がないか、適切なリンクに飛べているか


