### PR TITLE
GYDページのタイトルを変更

### DIFF
--- a/pages/global-youth-dialogue/index.vue
+++ b/pages/global-youth-dialogue/index.vue
@@ -12,7 +12,7 @@
   export default {
     head() {
       return{
-        title: 'aiesecjp-web',
+        title: 'global youth dialogue',
         meta: [
           {charset: 'utf-8'},
           {name: 'viewport', content: 'width=device-width, initial-scale=1'},


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->

## 概要
GYDページのタイトルを「global youth dialogue」に変更

## 変更内容
pages/global-youth-dialogue/index.vue の head 内で return している title の内容を、aiesecjp-web → global youth dialogue へ変更

## レビューポイント
タイトルが反映されているか


