### PR TITLE
Release/20220709

### DIFF
--- a/components/global-youth-dialogue/Top.vue
+++ b/components/global-youth-dialogue/Top.vue
@@ -7,9 +7,6 @@
         src="@/assets/images/global-youth-dialogue/global-youth-dialogue-logo-white-none.png"
       >
       <p class="global-youth-dialogue-text">
-        申し込み締め切り：5/18 開催日時：5/27~5/31
-      </p>
-      <p class="global-youth-dialogue-text">
         Pursue the answer for peace. <br>
         探求しよう、自分と世界の境界を超えて。
       </p>

--- a/pages/global-youth-dialogue/index.vue
+++ b/pages/global-youth-dialogue/index.vue
@@ -12,7 +12,7 @@
   export default {
     head() {
       return{
-        title: 'aiesecjp-web',
+        title: 'global youth dialogue',
         meta: [
           {charset: 'utf-8'},
           {name: 'viewport', content: 'width=device-width, initial-scale=1'},


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->

## 概要
GYDページのタイトルを「global youth dialogue」に変更

## 変更内容
pages/global-youth-dialogue/index.vue の head 内で return している title の内容を、
aiesecjp-web → global youth dialogue へ変更

## レビューポイント
差分


