### PR TITLE
components_base_footer.vueのGYDの頭文字を小文字に修正

### DIFF
--- a/components/base/Footer.vue
+++ b/components/base/Footer.vue
@@ -66,7 +66,7 @@
             class="footer-content-link"
             to="/global-youth-dialogue"
           >
-            Global Youth Dialogue
+            global youth dialogue
           </nuxt-link>
         </li>
       </ul>


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->

## 概要
<!-- 目的 -->
HP内でのGYDの表記の統一

## 変更内容
<!-- 実装の内容, スクショなど -->
<img width="205" alt="image" src="https://user-images.githubusercontent.com/101848739/184493589-a8c38d33-fc4c-42f3-af15-97f2c9bc3224.png">
HPのfooterのGlobal Youth Dialogueの単語の頭文字を全て小文字に変更

## レビューポイント
<!-- レビューで見てほしいところ -->


