### PR TITLE
渋谷さん肩書

### DIFF
--- a/components/about/AdvisorList.vue
+++ b/components/about/AdvisorList.vue
@@ -30,7 +30,7 @@
           },
           {
             caption : '諮問',
-            description : '渋谷 直毅（シティグループ証券株式会社 ディレクター）'
+            description : '渋谷 直毅'
           }
         ]
       }


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->

## 概要
諮問から肩書きを一時取り下げするよう要請があったため、渋谷諮問の肩書きを一時的に削除します

## 変更内容
about/AdvisorList.vue の諮問欄を修正

## レビューポイント
差分

