### PR TITLE
Meta Pixel Code 埋め込み

### DIFF
--- a/pages/global-youth-dialogue/index.vue
+++ b/pages/global-youth-dialogue/index.vue
@@ -33,10 +33,20 @@
           },
           {
             innerHTML: `window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-222793123-5');`
+          },
+          // Meta Pixel Code
+          {
+            innerHTML: `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init', '441541344740997');fbq('track', 'PageView');`
           }
         ],
         __dangerouslyDisableSanitizers: ['script'],
-      } 
+        noscript: [
+          {
+            innerHTML: `<img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=441541344740997&ev=PageView&noscript=1"/>`,
+          }
+        ],
+      }
+      
     }
   }
 </script>


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->

## 概要
GYD 有料広告開始にあたり、「HPとFacebookを紐付けるMetaピクセル」を導入するために、埋め込みコードを追加。

## 変更内容
pages/global-youth-dialogue/index.vue の head メソッド内、script に1つ、noscript に1つコードを追加。

## レビューポイント
記載方法が適切かどうか


