### PR TITLE
upd: 常務理事の担当者、監事の肩書の更新

### DIFF
--- a/components/about/OfficerList.vue
+++ b/components/about/OfficerList.vue
@@ -32,7 +32,7 @@ export default {
         },
         {
           caption: "常務理事",
-          description: "籔上りか子（同志社大学 商学部 4年）",
+          description: "飯塚創太（東京大学 法学部 3年）",
         },
         {
           caption: "理事",
@@ -56,7 +56,7 @@ export default {
         },
         {
           caption: "監事",
-          description: "太田康広（慶應義塾大学ビジネス・スクール教授）",
+          description: "太田康広（慶應義塾大学大学院経営管理研究科エーザイチェアシップ基金教授）",
         },
       ],
     };


### PR DESCRIPTION
## 概要
新年度の役員情報の反映

## 変更内容
常務理事：飯塚創太（東京大学 法学部 3年）
監事の肩書：慶應義塾大学大学院経営管理研究科エーザイチェアシップ基金教授


## レビューポイント
変更内容が正しいこと


