### PR TITLE
Feature/update officer advisor

### DIFF
--- a/components/about/AdvisorList.vue
+++ b/components/about/AdvisorList.vue
@@ -31,6 +31,10 @@
           {
             caption : '諮問',
             description : '渋谷 直毅'
+          },
+          {
+            caption : '諮問',
+            description : '福山和貴（アンダーソン・毛利・友常法律事務所 アソシエイツ）'
           }
         ]
       }

--- a/components/about/OfficerList.vue
+++ b/components/about/OfficerList.vue
@@ -24,11 +24,7 @@ export default {
         {
           caption: "副会長",
           description:
-            "松塚ゆかり（一橋大学森有礼高等教育国際流動化機構 教授）",
-        },
-        {
-          caption: "副会長",
-          description: "菊地端夫（明治大学 経営学部 教授）",
+            "西野史子（一橋大学 大学院社会学研究科 教授）",
         },
         {
           caption: "常務理事",


### PR DESCRIPTION
**諮問の追加、役員：副会長の変更**

〇諮問
- 諮問　  福山和貴（アンダーソン・毛利・友常法律事務所 アソシエイツ）


〇役員：副会長
変更前
- 副会長	松塚ゆかり	（一橋大学森有礼高等教育国際流動化機構 教授）
- 副会長	菊地端夫	（明治大学経営学部 教授）

変更後
- 副会長　　西野史子（一橋大学 大学院社会学研究科 教授）

