### PR TITLE
Feature/update quarter

### DIFF
--- a/components/about/CustomTable.vue
+++ b/components/about/CustomTable.vue
@@ -24,6 +24,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.aboutus-table{
+  font-family: $fonts;
+}
 th,
 td {
   border-bottom-style: solid;

--- a/components/about/OfficerList.vue
+++ b/components/about/OfficerList.vue
@@ -28,7 +28,7 @@ export default {
         },
         {
           caption: "常務理事",
-          description: "飯塚創太（東京大学 法学部 3年）",
+          description: "佐藤夕夏（東京女子大学 現代教養学部 4年）",
         },
         {
           caption: "理事",

--- a/components/about/OfficerList.vue
+++ b/components/about/OfficerList.vue
@@ -19,7 +19,7 @@ export default {
         },
         {
           caption: "専務理事",
-          description: "高橋祐哉（東京外国語大学 国際社会学部 4年）",
+          description: "森本大貴（大阪大学 工学部 4年）",
         },
         {
           caption: "副会長",

--- a/components/about/OrganizationInfo.vue
+++ b/components/about/OrganizationInfo.vue
@@ -31,7 +31,7 @@ export default {
             "各務茂夫 (東京大学 大学院工学系研究科 教授 産学協創推進本部 副本部長)",
         },
 
-        { caption: "専務理事", description: "高橋祐哉（東京外国語大学 4年）" },
+        { caption: "専務理事", description: "森本大貴 (大阪大学 4年)" },
 
         {
           caption: "所在地",

--- a/components/base/Header.vue
+++ b/components/base/Header.vue
@@ -84,16 +84,16 @@
           </nuxt-link>
         </li>
         <!-- 外部リンク -->
-        <li class="navigation-item">
+        <!-- <li class="navigation-item"> 新歓専用ページ(2022, 2023のみ使用し、2024で削除)
           <div class="lp-button">
             <a
               class="lp-button-text"
-              href="https://aiesec.jp/lp/recruit2023/"
+              href="https://aiesec.jp/lp/#"
             >
               Recruitment
             </a>
           </div>
-        </li>
+        </li> -->
       </ul>
       <div
         v-show="this.$isMobile() && drawer"

--- a/components/safety/Committee.vue
+++ b/components/safety/Committee.vue
@@ -21,7 +21,7 @@
         <div v-show="i <= 5 || openLogs">
           <h3>{{ item.title }}</h3>
           <p>
-            {{ item.describe }}<span v-show="!!item.link">詳細な報告につきましては <a :href="item.link">こちら</a>をご覧ください。</span>
+            {{ item.describe }}<span v-show="!!item.link">詳細な報告につきましては <a :href="item.link" target="_blank">こちら</a>をご覧ください。</span>
           </p>
         </div>
         <v-btn
@@ -42,6 +42,11 @@ export default {
     return {
       openLogs: false,
       committeeLogs: [
+        {
+          title: '令和五年度第二回海外安全管理委員会開催報告',
+          describe: '令和5年11月15日に海外安全管理委員会を開催いたしました。',
+          link: 'https://drive.google.com/file/d/1xW2J5VdO0ybeq5kCaHNfhBis0NYGLByY/view?usp=drive_link'
+        },
         {
           title: '令和五年度第一回海外安全管理委員会開催報告',
           describe: '令和5年5月31日に海外安全管理委員会を開催いたしました。',


### PR DESCRIPTION
## Issue
<!-- Issue番号 -->

## 概要
四半期のHP更新

## 変更内容
■ 安全管理委員会報告書の掲載 https://www.aiesec.jp/safety
「令和五年度第二回海外安全管理委員会開催報告」掲載
令和5年11月15日に海外安全管理委員会を開催いたしました。詳細な報告につきましては [こちら](https://drive.google.com/file/d/1xW2J5VdO0ybeq5kCaHNfhBis0NYGLByY/view?usp=drive_link)をご覧ください。

■ 新歓ページの削除
ヘッダーのRecruitボタンの削除
（コメントアウトにしています><）

■ 常務理事の変更 https://www.aiesec.jp/about
飯塚創太（東京大学 法学部 3年）を下記に変更
佐藤夕夏（東京女子大学 現代教養学部 4年）

## レビューポイント
変更内容が反映されているかどうか

